### PR TITLE
lib/buildClosure: copy flake .drv paths

### DIFF
--- a/src/lib.go
+++ b/src/lib.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // model 'nix build --json' output.
@@ -22,29 +23,48 @@ type JobSpec struct {
 
 func buildClosure(flake string, spec JobSpec, builder string) (string, error) {
 	expr := fmt.Sprintf("%s#%sConfigurations.%s.config.system.build.toplevel", flake, spec.Type, spec.Output)
+	drvExpr := expr + ".drvPath"
 
-	var data []byte
-	var err error
-
-	if builder != "localhost" {
-		data, err = runJSON("nix", "build", "--no-link", "--json", "--store", fmt.Sprintf("ssh-ng://%s", builder), expr)
-	} else {
-		data, err = runJSON("nix", "build", "--no-link", "--json", expr)
-	}
-
+	// Step 1: Evaluate the .drv path locally
+	data, err := runJSON("nix", "--extra-experimental-features", "nix-command flakes", "eval", "--raw", drvExpr)
 	if err != nil {
-		return "", fmt.Errorf("Failed to build %s: %v", spec.Output, err)
+		return "", fmt.Errorf("Failed to evaluate drvPath for %s: %w", spec.Output, err)
+	}
+	drvPath := strings.TrimSpace(string(data))
+
+	// Step 2: Copy the .drv closure to the remote builder (if needed)
+	if builder != "localhost" {
+		if _, err := run("nix", "--extra-experimental-features", "nix-command flakes", "copy", "--to", "ssh-ng://"+builder, drvPath); err != nil {
+			return "", fmt.Errorf("Failed to copy .drv to %s: %w", builder, err)
+		}
 	}
 
-	var res []BuildResult
-	if err := json.Unmarshal(data, &res); err != nil {
-		return "", fmt.Errorf("Bad build JSON for %s: %v", spec.Output, err)
+	// Step 3: Build the closure from the drv remotely or locally
+	var buildOut []byte
+	if builder != "localhost" {
+		buildOut, err = runJSON("nix", "--extra-experimental-features", "nix-command flakes", "build", "--no-link", "--json", "--store", "ssh-ng://"+builder, drvPath+"^*")
+	} else {
+		buildOut, err = runJSON("nix", "--extra-experimental-features", "nix-command flakes", "build", "--no-link", "--json", drvPath+"^*")
+	}
+	if err != nil {
+		return "", fmt.Errorf("Failed to build %s on %s: %w", spec.Output, builder, err)
 	}
 
-	out, ok := res[0].Outputs["out"]
+	// Step 4: Parse the output path
+	var results []BuildResult
+	if err := json.Unmarshal(buildOut, &results); err != nil {
+		return "", fmt.Errorf("Invalid build JSON for %s: %w\nRaw: %s", spec.Output, err, string(buildOut))
+	}
+	if len(results) == 0 {
+		return "", fmt.Errorf("Build result for %s was empty", spec.Output)
+	}
+	out, ok := results[0].Outputs["out"]
 	if !ok {
-		return "", fmt.Errorf("Missing 'out' for %s", spec.Output)
-	} else if builder != "localhost" {
+		return "", fmt.Errorf("Missing 'out' key in build result for %s", spec.Output)
+	}
+
+	// Step 5: Copy built closure back from builder to local (if needed)
+	if builder != "localhost" {
 		if _, err := run("nix", "copy", "--from", "ssh-ng://"+builder, out, "--no-check-sigs"); err != nil {
 			return "", fmt.Errorf("Error copying from %s: %v", builder, err)
 		}


### PR DESCRIPTION
Ensures we evaluate the flake locally before building remotely, so the flake inputs etc are available. Mirrors similar behavior from nixos-rebuild/nixos-rebuild-ng